### PR TITLE
Fixed the enemy stat creation

### DIFF
--- a/Assets/My Assets/_Scripts/Game/Character/Enemy/BaseEnemyController.cs
+++ b/Assets/My Assets/_Scripts/Game/Character/Enemy/BaseEnemyController.cs
@@ -62,15 +62,15 @@ public class BaseEnemyController : PawnController {
     private void CreateStats()
     {
         int totalHealthEnergy = player.GetTotalHeatlhEnergyStats();
-        healthEnergy = totalHealthEnergy + Mathf.FloorToInt((totalHealthEnergy * Random.Range(-0.2f, 0.1f)));
-        totalHealth = Mathf.FloorToInt(healthEnergy * Random.Range(0.45f, 0.65f));
+        healthEnergy = totalHealthEnergy + Mathf.FloorToInt((totalHealthEnergy * Random.Range(-0.2f, 0.2f)));
+        totalHealth = Mathf.FloorToInt(healthEnergy * Random.Range(0.45f, 0.75f));
         totalEnergy = healthEnergy - totalHealth;
-        physicalDamage = player.GetTotalArmor() + Mathf.FloorToInt(player.GetTotalArmor() * Random.Range(-0.2f, 0.1f));
-        armor = player.GetTotalDamage() + Mathf.FloorToInt(player.GetTotalDamage() * Random.Range(-0.2f, 0.1f));
+        physicalDamage = (int)(player.GetTotalArmor() + player.GetTotalArmor() * Random.Range(-0.2f, 0.1f));
+        armor = (int)(player.GetTotalDamage() + player.GetTotalDamage() * Random.Range(-0.2f, 0.1f));
 
-        Debug.Log( " EnemyTotalHealth: " + totalHealth + 
+        Debug.Log(" EnemyTotalHealth: " + totalHealth +
             " EnemyTotalEnergy: " + totalEnergy +
-            " EnemyPhysicalDamaga: " + physicalDamage + 
+            " EnemyPhysicalDamaga: " + physicalDamage +
             " EnemyArmor: " + armor);
     }
 

--- a/Assets/My Assets/_Scripts/Game/Character/PawnController.cs
+++ b/Assets/My Assets/_Scripts/Game/Character/PawnController.cs
@@ -463,7 +463,7 @@ public class PawnController : MonoBehaviour
     /// <returns></returns>
     public int GetTotalArmor()
     {
-        return this.armor + this.playerArmor.GetDefMod() + this.playerWeapon.GetDefMod();
+        return this.armor;// + this.playerArmor.GetDefMod() + this.playerWeapon.GetDefMod();
     }
     /// <summary>
     /// Gets the total damage.
@@ -471,7 +471,7 @@ public class PawnController : MonoBehaviour
     /// <returns>The total damage.</returns>
     public int GetTotalDamage()
     {
-        return this.physicalDamage + this.playerArmor.GetAtkMod() + this.playerWeapon.GetAtkMod();
+        return this.physicalDamage;// + this.playerArmor.GetAtkMod() + this.playerWeapon.GetAtkMod();
     }
 
     public int GetTotalHeatlhEnergyStats()


### PR DESCRIPTION
Now properly creates stats in the range of the player's stats.

Also tweaked the range of the Health and Energy.
Now +- 20% of player's total Health and Energy.  First Health is 45% to
75% of that number and the Energy is the remaining.
